### PR TITLE
Added Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.dockerignore
+.git
+.gitignore
+Dockerfile
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM dstelljes/smac:2.10
+
+RUN dnf install -y bzip2 gcc gcc-c++ git make python tar
+
+WORKDIR /
+ADD http://www.cril.univ-artois.fr/~roussel/runsolver/runsolver-3.3.5.tar.bz2 ./
+RUN tar -jxf runsolver*.tar.bz2
+RUN rm -f runsolver*.tar.bz2
+RUN mv runsolver runsolver-3.3.5
+WORKDIR /runsolver-3.3.5/src
+RUN sed -i -r 's/^(CFLAGS.*)$/\1 -std=gnu++98/' Makefile
+RUN make
+RUN mv runsolver /runsolver
+WORKDIR /
+RUN rm -rf /runsolver-3.3.5
+
+ADD https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein /usr/bin/lein
+RUN chmod +x /usr/bin/lein
+RUN git clone https://github.com/lspector/Clojush.git clojush
+WORKDIR /clojush
+RUN lein uberjar
+RUN cp target/clojush-*-standalone.jar /clojush-standalone.jar
+WORKDIR /
+RUN rm -rf /clojush /root/.lein /usr/bin/lein
+
+ADD * ./
+RUN ln -s /usr/bin/smac smac
+RUN mkdir smac-output
+
+RUN dnf remove -y bzip2 gcc gcc-c++ git make tar
+RUN dnf clean all
+
+VOLUME /smac-output

--- a/run-clojush.py
+++ b/run-clojush.py
@@ -71,7 +71,7 @@ arg_dict[":alternation-rate"] = alt_rate
 arg_dict[":alignment-deviation"] = alignment_dev
 arg_dict[":uniform-mutation-rate"] = uni_mut_rate
 
-uberjar = "clojush-2.0.73-SNAPSHOT-standalone.jar"
+uberjar = "clojush-standalone.jar"
 runsolver_time_file = "/tmp/smac_runsolver_time_" + str(seed) + ".txt"
 command = ["./runsolver", "-v", runsolver_time_file, "-C", str(wallclock_limit), "java", "-jar", uberjar, problem]
 for key in arg_dict:


### PR DESCRIPTION
The Dockerfile describes a quick and dirty image that deals with all of the setup stuff outlined in the README. The assumptions in `run-clojush.py` are maintained with the exception of the Clojush uberjar location (I used `clojush-standalone.jar` instead of `clojush-2.0.73-SNAPSHOT-standalone.jar`).

For now, the scenario files are baked into the image, though that wouldn't be difficult to change. Building the image and running SMAC looks something like this:

    cd smac-clojush
    docker build -t smac-clojush:latest .
    docker run -it -v /home/stell124/smac-talk:/smac-output smac-clojush:latest -- smac --scenario-file scenario-whatever.txt

🐙